### PR TITLE
提交修改 调整JSON序列化选项 将System.Text.Json 更换为 Newtonsoft.Json

### DIFF
--- a/src/core/Air.Cloud.Core/Air.Cloud.Core.csproj
+++ b/src/core/Air.Cloud.Core/Air.Cloud.Core.csproj
@@ -31,13 +31,15 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.32" />
     <PackageReference Include="XC.RSAUtil" Version="1.3.6" />
     <PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
     <PackageReference Include="Mapster" Version="7.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
-    <Protobuf Include="Protos\*.proto" GrpcServices="Client" Link="Protos\%(RecursiveDir)%(Filename)%(Extension)" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <Protobuf Include="Protos\*.proto" GrpcServices="Client" Link="Protos\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/src/core/Air.Cloud.Core/AppRealization.cs
+++ b/src/core/Air.Cloud.Core/AppRealization.cs
@@ -188,7 +188,7 @@ namespace Air.Cloud.Core
             /// <summary>
             /// JSON序列化标准实现
             /// </summary>
-            public static IJsonSerializerStandard JSON => new DefaultJsonSerializerStandardDependency(AppCore.GetOptions<JsonOptions>());
+            public static IJsonSerializerStandard JSON => new DefaultJsonSerializerStandardDependency();
 
             /// <summary>
             /// 应用程序PID信息 

--- a/src/core/Air.Cloud.Core/Standard/DefaultDependencies/DefaultJsonSerializerStandardDependency.cs
+++ b/src/core/Air.Cloud.Core/Standard/DefaultDependencies/DefaultJsonSerializerStandardDependency.cs
@@ -10,56 +10,41 @@
  * acknowledged.
  */
 using Air.Cloud.Core.Standard.JSON;
-using Air.Cloud.Core.Standard.JSON.Converters;
-
-using Mapster;
 
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Rewrite;
-using Microsoft.Extensions.Options;
 
-using System.Text.Encodings.Web;
-using System.Text.Json;
-using System.Text.Unicode;
+using Newtonsoft.Json;
 
 namespace Air.Cloud.Core.Standard.DefaultDependencies
 {
+    /// <summary>
+    /// <para>zh-cn:默认JSON序列化实现 引用了Newtonsoft.Json</para>
+    /// <para>en-us:Default json serializer dependency</para>
+    /// </summary>
     public class DefaultJsonSerializerStandardDependency : IJsonSerializerStandard
     {
         /// <summary>
-        /// 获取 JSON 配置选项
+        /// <para>zh-cn:配置项</para>
+        /// <para>en-us:JsonSerializerSettings</para>
         /// </summary>
-        private readonly JsonOptions _jsonOptions;
+        private static JsonSerializerSettings JsonSerializerSettings;
 
         /// <summary>
-        /// 构造函数
+        /// 初始化配置
         /// </summary>
-        /// <param name="options"></param>
-        public DefaultJsonSerializerStandardDependency(IOptions<JsonOptions> options)
+        public DefaultJsonSerializerStandardDependency()
         {
-            _jsonOptions = options.Value;
-        }
-        /// <summary>
-        /// 构造函数
-        /// </summary>
-        /// <param name="options"></param>
-        public DefaultJsonSerializerStandardDependency(JsonOptions options)
-        {
-            //
-            var optionss = options.Adapt<JsonOptions>();
-            optionss.JsonSerializerOptions.Encoder = JavaScriptEncoder.Create(UnicodeRanges.All);
-            optionss.JsonSerializerOptions.Converters.Add(new ExceptionJsonConverter<Exception>());
-            _jsonOptions = optionss;
+            var s = AppCore.GetOptions<MvcNewtonsoftJsonOptions>();
+            JsonSerializerSettings = (s?.SerializerSettings)??new JsonSerializerSettings();
         }
         /// <summary>
         /// 序列化对象
         /// </summary>
         /// <param name="value"></param>
-        /// <param name="jsonSerializerOptions"></param>
         /// <returns></returns>
-        public string Serialize(object value, JsonSerializerOptions jsonSerializerOptions = null)
+        public string Serialize(object value)
         {
-            return JsonSerializer.Serialize(value, (jsonSerializerOptions ?? GetSerializerOptions()) as JsonSerializerOptions);
+            return JsonConvert.SerializeObject(value,JsonSerializerSettings);
         }
 
         /// <summary>
@@ -67,22 +52,10 @@ namespace Air.Cloud.Core.Standard.DefaultDependencies
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="json"></param>
-        /// <param name="jsonSerializerOptions"></param>
         /// <returns></returns>
-        public T Deserialize<T>(string json, JsonSerializerOptions jsonSerializerOptions = null)
+        public T Deserialize<T>(string json)
         {
-            return JsonSerializer.Deserialize<T>(json, (jsonSerializerOptions ?? GetSerializerOptions()) as JsonSerializerOptions);
-        }
-
-        /// <summary>
-        /// 返回读取全局配置的 JSON 选项
-        /// </summary>
-        /// <returns></returns>
-        public object GetSerializerOptions()
-        {
-            //_jsonOptions?.JsonSerializerOptions.Converters.Add(new ExceptionJsonConverter<Exception>());
-            var options = _jsonOptions?.JsonSerializerOptions;
-            return options;
+            return JsonConvert.DeserializeObject<T>(json, JsonSerializerSettings);
         }
     }
 }

--- a/src/core/Air.Cloud.Core/Standard/JSON/IJsonSerializerStandard.cs
+++ b/src/core/Air.Cloud.Core/Standard/JSON/IJsonSerializerStandard.cs
@@ -11,36 +11,26 @@
  */
 using Air.Cloud.Core.Dependencies;
 
-using System.Text.Json;
-
 namespace Air.Cloud.Core.Standard.JSON
 {
     /// <summary>
     /// JSON 序列化器标准接口
     /// </summary>
-    public  interface IJsonSerializerStandard: ISingleton
+    public  interface IJsonSerializerStandard: IStandard,ISingleton
     {
         /// <summary>
         /// 序列化对象
         /// </summary>
         /// <param name="value"></param>
-        /// <param name="jsonSerializerOptions"></param>
         /// <returns></returns>
-        string Serialize(object value, JsonSerializerOptions jsonSerializerOptions = default);
+        string Serialize(object value);
 
         /// <summary>
         /// 反序列化字符串
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="json"></param>
-        /// <param name="jsonSerializerOptions"></param>
         /// <returns></returns>
-        T Deserialize<T>(string json, JsonSerializerOptions jsonSerializerOptions = default);
-
-        /// <summary>
-        /// 返回读取全局配置的 JSON 选项
-        /// </summary>
-        /// <returns></returns>
-        object GetSerializerOptions();
+        T Deserialize<T>(string json);
     }
 }

--- a/src/modules/Air.Cloud.Modules.Consul/Air.Cloud.Modules.Consul.csproj
+++ b/src/modules/Air.Cloud.Modules.Consul/Air.Cloud.Modules.Consul.csproj
@@ -16,7 +16,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <PackAsTool>False</PackAsTool>
-    <Version>1.0.1.3</Version>
+    <Version>1.0.1.4</Version>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/modules/Air.Cloud.Modules.IIS/Air.Cloud.Modules.IIS.csproj
+++ b/src/modules/Air.Cloud.Modules.IIS/Air.Cloud.Modules.IIS.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/unit.taxin/unit.taxinserver.entry/Startup.cs
+++ b/test/unit.taxin/unit.taxinserver.entry/Startup.cs
@@ -20,6 +20,9 @@ using Air.Cloud.Modules.Taxin.Server;
 using Air.Cloud.WebApp.Extensions;
 using Air.Cloud.WebApp.UnifyResult.Extensions;
 
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json;
+
 using System.Text.Encodings.Web;
 using System.Text.Unicode;
 
@@ -37,7 +40,13 @@ namespace unit.taxinserver.entry
             {
                 a.Filters.Add<ActionLogFilter>();
                 a.Filters.Add<AutoSaveChangesFilter>();
-            }).AddInjectWithUnifyResult();
+            }).AddInjectWithUnifyResult().AddNewtonsoftJson(s =>
+            {
+                //全局设置json 序列化enum int 转string
+                s.SerializerSettings.Converters.Add(new IsoDateTimeConverter()
+                { DateTimeFormat = "yyyy-MM-dd HH:mm:ss" });
+                s.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
+            });
         }
         public override void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {

--- a/test/unit.webapp/unit.webapp.entry/Program.cs
+++ b/test/unit.webapp/unit.webapp.entry/Program.cs
@@ -16,6 +16,6 @@ using Air.Cloud.WebApp.DataValidation.Attributes;
 using Air.Cloud.Modules.Consul.Extensions;
 var builder = WebApplication.CreateBuilder(args);
 
-var app = builder.WebInjectInConsul();
+var app = builder.WebInjectInFile();
 
 app.Run();


### PR DESCRIPTION
因为某些JSON序列化默认选项的错误设置,导致处理数据时出现问题 但是使用Newtonsoft.Json 未发现此类问题 所以将其默认的调整为 Newtonsoft.Json